### PR TITLE
Filename invalid, causes key error when executing S3 retrieval cell

### DIFF
--- a/source/industry/telecom/notebooks/Ml-Telecom-RandomCutForest.ipynb
+++ b/source/industry/telecom/notebooks/Ml-Telecom-RandomCutForest.ipynb
@@ -53,7 +53,7 @@
     "# Using S3 Select to retrieve data \n",
     "s3 = boto3.client('s3')\n",
     "bucket_name = '<%bucket_name%>'  # <-- use your own bucket, here\n",
-    "file_name = 'machine-learning-for-all/v1.0/data/cdr-stop/cdr_stop.csv'\n",
+    "file_name = 'machine-learning-for-all/v1.0.0/data/cdr-stop/cdr_stop.csv'\n",
     "\n",
     "sql_stmt = \"\"\"SELECT * FROM s3object\"\"\"\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

Invalid filename in MI-Telecom-RandomCutForest notebook. Causes error when trying to run the S3 retrieval cell with the provided sample data.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.